### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Unichat MCP Server in Python
 Also available in [TypeScript](https://github.com/amidabuddha/unichat-ts-mcp-server)
+[![smithery badge](https://smithery.ai/badge/unichat-mcp-server)](https://smithery.ai/server/unichat-mcp-server)
 --
 Send requests to OpenAI, MistralAI, Anthropic, xAI, or Google AI using MCP protocol via tool or predefined prompts.
 Vendor API key required
@@ -73,6 +74,14 @@ Published Servers Configuration
     }
   }
 }
+```
+
+### Installing via Smithery
+
+To install Unichat for Claude Desktop automatically via [Smithery](https://smithery.ai/server/unichat-mcp-server):
+
+```bash
+npx -y @smithery/cli install unichat-mcp-server --client claude
 ```
 
 ## Development


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Unichat for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/unichat-mcp-server

Let me know if any tweaks have to be made!