### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ npx @modelcontextprotocol/inspector uv --directory {{your source code local dire
 
 
 Upon launching, the Inspector will display a URL that you can access in your browser to begin debugging.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/amidabuddha-unichat-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/amidabuddha-unichat-mcp-server).